### PR TITLE
Changed for burning XEN & using the single token for stacking and rewards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 SEPOLIA_PROVIDER_URL=Full url of your provider (for example Alchemy), including API key
 SEPOLIA_PRIVATE_KEY=private key to an account with enough assets for deployment
+GOERLI_PROVIDER_URL=Full url of your provider (for example Alchemy), including API key
+GOERLI_PRIVATE_KEY=private key to an account with enough assets for deployment
 ETHERSCAN_API_KEY=API key for Etherscan to verify the contracts

--- a/contracts/RewardsDistributionRecipient.sol
+++ b/contracts/RewardsDistributionRecipient.sol
@@ -5,7 +5,11 @@ pragma solidity ^0.8.17;
  * @notice An abstract contract to define functionality for reward distributer
  */
 abstract contract RewardsDistributionRecipient {
-    address public rewardsDistribution;
+    address immutable rewardsDistribution;
+
+    constructor(address _rewardsDistribution) {
+        rewardsDistribution = _rewardsDistribution;
+    }
 
     function notifyRewardAmount(uint256 reward) external virtual;
 

--- a/contracts/RewardsDistributionRecipient.sol
+++ b/contracts/RewardsDistributionRecipient.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
  * @notice An abstract contract to define functionality for reward distributer
  */
 abstract contract RewardsDistributionRecipient {
-    address immutable rewardsDistribution;
+    address public immutable rewardsDistribution;
 
     constructor(address _rewardsDistribution) {
         rewardsDistribution = _rewardsDistribution;

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -136,10 +136,10 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
             return rewardPerTokenStored;
         }
         return
-            rewardPerTokenStored +
-            (((lastTimeRewardApplicable() - lastUpdateTime) *
-                rewardRate *
-                1e18) / _totalSupply);
+        rewardPerTokenStored +
+        (((lastTimeRewardApplicable() - lastUpdateTime) *
+        rewardRate *
+        1e18) / _totalSupply);
     }
 
     /**
@@ -148,9 +148,9 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
      */
     function earned(address account) public view returns (uint256) {
         return
-            ((_balances[account] *
-                (rewardPerToken() - userRewardPerTokenPaid[account])) / 1e18) +
-            rewards[account];
+        ((_balances[account] *
+        (rewardPerToken() - userRewardPerTokenPaid[account])) / 1e18) +
+        rewards[account];
     }
 
     /**
@@ -171,7 +171,10 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
     ) external nonReentrant updateReward(msg.sender) {
         require(amount > 0, "Cannot stake 0");
         //NOTE: Decimals of staking token should be the same as XEN
-        IBurnableToken(xenToken).burn(msg.sender, amount * xenBurnPercent / 10000);
+        uint256 xenBurnAmount = amount * xenBurnPercent / 10000;
+        if (xenBurnAmount > 0) {
+            IBurnableToken(xenToken).burn(msg.sender, xenBurnAmount);
+        }
         _totalSupply = _totalSupply + amount;
         _balances[msg.sender] = _balances[msg.sender] + amount;
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -3,13 +3,15 @@ pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import "./RewardsDistributionRecipient.sol";
+import "./interfaces/IBurnRedeemable.sol";
 
 /**
  * @notice A staking contract based on Synthetix staking
  */
-contract StakingRewards is RewardsDistributionRecipient, ReentrancyGuard {
+contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /* ========== STATE VARIABLES ========== */
@@ -79,6 +81,15 @@ contract StakingRewards is RewardsDistributionRecipient, ReentrancyGuard {
     }
 
     /* ========== VIEWS ========== */
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165) returns (bool) {
+        return
+        interfaceId == type(IBurnRedeemable).interfaceId ||
+        super.supportsInterface(interfaceId);
+    }
 
     /**
      * @notice Total staked tokens
@@ -217,6 +228,14 @@ contract StakingRewards is RewardsDistributionRecipient, ReentrancyGuard {
         lastUpdateTime = block.timestamp;
         periodFinish = block.timestamp + rewardsDuration;
         emit RewardAdded(reward);
+    }
+
+    /**
+    * @notice Recover ERC20 tokens from the contract
+    * @param user Address of the token to recover
+    * @param amount How much to recover
+    */
+    function onTokenBurned(address user, uint256 amount) external {
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -29,7 +29,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
     /**
      * @notice Address of the XEN token
      */
-    IBurnableToken public xenToken;
+    address public xenToken;
 
     /**
      * @notice Percentage of XEN to be burned multiplied by 100
@@ -91,7 +91,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
     ) RewardsDistributionRecipient(_rewardsDistribution) {
         rewardsToken = IERC20(_rewardsToken);
         stakingToken = IERC20(_stakingToken);
-        xenToken = IBurnableToken(_xenToken);
+        xenToken = _xenToken;
     }
 
     /* ========== VIEWS ========== */
@@ -170,7 +170,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
     ) external nonReentrant updateReward(msg.sender) {
         require(amount > 0, "Cannot stake 0");
         //NOTE: Decimals of staking token should be the same as XEN
-        xenToken.burn(msg.sender, amount * xenBurnPercent / 10000);
+        IBurnableToken(xenToken).burn(msg.sender, amount * xenBurnPercent / 10000);
         _totalSupply = _totalSupply + amount;
         _balances[msg.sender] = _balances[msg.sender] + amount;
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
@@ -248,10 +248,8 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
 
     /**
     * @notice Recover ERC20 tokens from the contract
-    * @param user Address of the token to recover
-    * @param amount How much to recover
     */
-    function onTokenBurned(address user, uint256 amount) external {
+    function onTokenBurned(address, uint256) view external {
         require(msg.sender == xenToken, "Caller must be XENCrypto");
     }
 

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -19,10 +19,6 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
     /* ========== STATE VARIABLES ========== */
 
     /**
-     * @notice Token to be used for the rewards
-     */
-    IERC20 public rewardsToken;
-    /**
      * @notice Token to be used for staking
      */
     IERC20 public stakingToken;
@@ -41,18 +37,22 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
      * @notice At which timestamp the current staking period ends
      */
     uint256 public periodFinish = 0;
+
     /**
      * @notice How many reward tokens to reward per second per staked token
      */
     uint256 public rewardRate = 0;
+
     /**
      * @notice Duration of the staking period
      */
     uint256 public rewardsDuration = 7 days;
+
     /**
      * @notice When were rewards input the last time
      */
     uint256 public lastUpdateTime;
+
     /**
      * @notice Previous reward rate
      */
@@ -62,6 +62,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
      * @notice How many tokens have already been paid to the user
      */
     mapping(address => uint256) public userRewardPerTokenPaid;
+
     /**
      * @notice How much rewards the address should get
      */
@@ -71,6 +72,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
      * @notice How many tokens have been staked in total
      */
     uint256 private _totalSupply;
+
     /**
      * @notice How much each address has staked
      */
@@ -81,16 +83,14 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
     /**
      * @dev Called when the contract is being deployed
      * @param _rewardsDistribution The address which is allowed to send rewards
-     * @param _rewardsToken Token to be used as rewards
      * @param _stakingToken Token to be staked in the contract
+     * @param _xenToken Address of the XEN token
      */
     constructor(
         address _rewardsDistribution,
-        address _rewardsToken,
         address _stakingToken,
         address _xenToken
     ) RewardsDistributionRecipient(_rewardsDistribution) {
-        rewardsToken = IERC20(_rewardsToken);
         stakingToken = IERC20(_stakingToken);
         xenToken = _xenToken;
     }
@@ -199,7 +199,7 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
         uint256 reward = rewards[msg.sender];
         if (reward > 0) {
             rewards[msg.sender] = 0;
-            rewardsToken.safeTransfer(msg.sender, reward);
+            stakingToken.safeTransfer(msg.sender, reward);
             emit RewardPaid(msg.sender, reward);
         }
     }
@@ -236,9 +236,9 @@ contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistribution
         // This keeps the reward rate in the right range, preventing overflows due to
         // very high values of rewardRate in the earned and rewardsPerToken functions;
         // Reward + leftover must be less than 2^256 / 10^18 to avoid overflow.
-        uint balance = rewardsToken.balanceOf(address(this));
+        uint rewardBalance = stakingToken.balanceOf(address(this)) - _totalSupply;
         require(
-            rewardRate <= balance / rewardsDuration,
+            rewardRate <= rewardBalance / rewardsDuration,
             "Provided reward too high"
         );
 

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./RewardsDistributionRecipient.sol";
 import "./interfaces/IBurnRedeemable.sol";
@@ -12,7 +13,7 @@ import "./interfaces/IBurnableToken.sol";
 /**
  * @notice A staking contract based on Synthetix staking
  */
-contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient, ReentrancyGuard {
+contract StakingRewards is IBurnRedeemable, ERC165, Ownable, RewardsDistributionRecipient, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /* ========== STATE VARIABLES ========== */
@@ -253,6 +254,15 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
         require(msg.sender == xenToken, "Caller must be XENCrypto");
     }
 
+    /**
+     * @notice Change xenBurnPercent
+     */
+    function setXenBurnPercent(uint16 _xenBurnPercent) external onlyOwner {
+        require(_xenBurnPercent <= 10000, "xenBurnPercent must be less than or equal to 10000");
+        xenBurnPercent = _xenBurnPercent;
+        emit XenBurnPercentUpdated(_xenBurnPercent);
+    }
+
     /* ========== MODIFIERS ========== */
 
     modifier updateReward(address account) {
@@ -273,4 +283,5 @@ contract StakingRewards is IBurnRedeemable, ERC165, RewardsDistributionRecipient
     event RewardPaid(address indexed user, uint256 reward);
     event RewardsDurationUpdated(uint256 newDuration);
     event Recovered(address token, uint256 amount);
+    event XenBurnPercentUpdated(uint16 newPercent);
 }

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -73,10 +73,9 @@ contract StakingRewards is RewardsDistributionRecipient, ReentrancyGuard {
         address _rewardsDistribution,
         address _rewardsToken,
         address _stakingToken
-    ) {
+    ) RewardsDistributionRecipient(_rewardsDistribution) {
         rewardsToken = IERC20(_rewardsToken);
         stakingToken = IERC20(_stakingToken);
-        rewardsDistribution = _rewardsDistribution;
     }
 
     /* ========== VIEWS ========== */

--- a/contracts/interfaces/IBurnRedeemable.sol
+++ b/contracts/interfaces/IBurnRedeemable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+interface IBurnRedeemable {
+    event Redeemed(
+        address indexed user,
+        address indexed xenContract,
+        address indexed tokenContract,
+        uint256 xenAmount,
+        uint256 tokenAmount
+    );
+
+    function onTokenBurned(address user, uint256 amount) external;
+}

--- a/contracts/interfaces/IBurnableToken.sol
+++ b/contracts/interfaces/IBurnableToken.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+interface IBurnableToken {
+    function burn(address user, uint256 amount) external;
+}

--- a/contracts/mocks/MockStakingRewards.sol
+++ b/contracts/mocks/MockStakingRewards.sol
@@ -12,13 +12,4 @@ contract MockStakingRewards is StakingRewards {
         address _stakingToken,
         address _xenToken
     ) StakingRewards(_rewardsDistribution, _stakingToken, _xenToken) {}
-
-    /**
-     * @notice Change the staking period duration. Only use when no active staking period
-     * @param newDays New duration of the staking period, in days
-     */
-    function changeStakingPeriod(uint256 newDays) public {
-        uint256 inSeconds = newDays * 60 * 60 * 24;
-        rewardsDuration = inSeconds;
-    }
 }

--- a/contracts/mocks/MockStakingRewards.sol
+++ b/contracts/mocks/MockStakingRewards.sol
@@ -10,8 +10,9 @@ contract MockStakingRewards is StakingRewards {
     constructor(
         address _rewardsDistribution,
         address _rewardsToken,
-        address _stakingToken
-    ) StakingRewards(_rewardsDistribution, _rewardsToken, _stakingToken) {}
+        address _stakingToken,
+        address _xenToken
+    ) StakingRewards(_rewardsDistribution, _rewardsToken, _stakingToken, _xenToken) {}
 
     /**
      * @notice Change the staking period duration. Only use when no active staking period

--- a/contracts/mocks/MockStakingRewards.sol
+++ b/contracts/mocks/MockStakingRewards.sol
@@ -9,10 +9,9 @@ import "../StakingRewards.sol";
 contract MockStakingRewards is StakingRewards {
     constructor(
         address _rewardsDistribution,
-        address _rewardsToken,
         address _stakingToken,
         address _xenToken
-    ) StakingRewards(_rewardsDistribution, _rewardsToken, _stakingToken, _xenToken) {}
+    ) StakingRewards(_rewardsDistribution, _stakingToken, _xenToken) {}
 
     /**
      * @notice Change the staking period duration. Only use when no active staking period

--- a/contracts/mocks/MockXEN.sol
+++ b/contracts/mocks/MockXEN.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../interfaces/IBurnableToken.sol";
+
+contract MockXEN is IBurnableToken {
+    function burn(address user, uint256 amount) external {
+
+    }
+}

--- a/contracts/mocks/MockXEN.sol
+++ b/contracts/mocks/MockXEN.sol
@@ -2,9 +2,24 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/IBurnableToken.sol";
+import "../interfaces/IBurnRedeemable.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract MockXEN is IBurnableToken {
+    mapping(address => uint256) internal userBurns;
     function burn(address user, uint256 amount) external {
+        require(
+            IERC165(msg.sender).supportsInterface(
+                type(IBurnRedeemable).interfaceId
+            ),
+            "Burn: not a supported contract"
+        );
 
+        userBurns[user] += amount;
+        IBurnRedeemable(msg.sender).onTokenBurned(user, amount);
+    }
+
+    function burnedBy(address user) external view returns (uint256) {
+        return userBurns[user];
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,6 +17,10 @@ const config: HardhatUserConfig = {
       url: process.env.SEPOLIA_PROVIDER_URL,
       accounts: [process.env.SEPOLIA_PRIVATE_KEY!],
     },
+    goerli: {
+      url: process.env.GOERLI_PROVIDER_URL,
+      accounts: [process.env.GOERLI_PRIVATE_KEY!],
+    }
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,

--- a/test/StakingRewards.test.ts
+++ b/test/StakingRewards.test.ts
@@ -254,6 +254,14 @@ describe("StakingRewards", function () {
         expect(balance).to.equal(oneToken);
       });
 
+      it("XEN burned right amount", async function () {
+        await stakingContract.connect(staker1).stake(oneToken);
+
+        const burned = await xenToken.connect(staker1).burnedBy(staker1.address);
+
+        expect(burned).to.equal(oneToken.div(100));
+      });
+
       it("Staking without rewards gives nothing", async function () {
         await stakingContract.connect(staker1).stake(oneToken);
 

--- a/test/StakingRewards.test.ts
+++ b/test/StakingRewards.test.ts
@@ -47,7 +47,7 @@ describe("StakingRewards", function () {
     await _staking.deployed();
 
     const _stakingContr: MockStakingRewards = _staking;
-    await _stakingContr.changeStakingPeriod(8);
+    //await _stakingContr.changeStakingPeriod(8);
 
     return {
       _deployer,
@@ -440,12 +440,12 @@ describe("StakingRewards", function () {
         await stakingContract.connect(staker1).stake(oneToken);
 
         await sendRewards(twoTokens);
-        await timeTravelDays(4);
+        await timeTravelDays(3.5);
 
         // Second staker starts with the same stake amount
         await stakingContract.connect(staker2).stake(oneToken);
 
-        await timeTravelDays(4);
+        await timeTravelDays(3.5);
 
         const earned1 = await stakingContract.earned(staker1.address);
         const earned2 = await stakingContract.earned(staker2.address);
@@ -464,12 +464,12 @@ describe("StakingRewards", function () {
         await stakingContract.connect(staker2).stake(oneToken);
 
         await sendRewards(twoTokens);
-        await timeTravelDays(4);
+        await timeTravelDays(3.5);
 
         // Second staker withdraws stake
         await stakingContract.connect(staker2).withdraw(oneToken);
 
-        await timeTravelDays(4);
+        await timeTravelDays(3.5);
 
         const earned1 = await stakingContract.earned(staker1.address);
         const earned2 = await stakingContract.earned(staker2.address);


### PR DESCRIPTION
- [Added goerli config](https://github.com/microbecode/pulsestaking/commit/3e371ebf9bfbba1969801aa715d6e3f378b2a20c)
- [Updated RewardsDistributionRecipient](https://github.com/microbecode/pulsestaking/commit/60e121f33fd25fa0b3c1d483586e33aeb1f25277)
- [Added IBurnRedeemable. Implemented ERC165](https://github.com/microbecode/pulsestaking/commit/eefb7ae233df4f03d59265e6cff0ac5dd072e1d9)
- [Added burn of XEN token.](https://github.com/microbecode/pulsestaking/commit/a8ff08a48d01bd77ef7fbed9d9d90e6b297f4c49)
- ~[Added ownable & ability to change xenBurnPercent](https://github.com/microbecode/pulsestaking/commit/c71c956662af36c77b0a26965a83746d99a05764)~
- [Removed rewardToken](https://github.com/microbecode/pulsestaking/commit/541c5e74b2cdaf11dc5f5a2c22a234ff63375f36)
- [Updated tests](https://github.com/microbecode/pulsestaking/commit/d5c7f2185618106e190ea7c557567d336a832ad1)
- [Added test for burned XEN amount](https://github.com/dkulyk/pulsestaking/pull/1/commits/a0b2450651ba30852e3d963e2dbf8d8252234738)